### PR TITLE
Clean up code samples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,14 @@ To use the SDK, initialize StorageApi with a configuration object. This will cre
 const { Configuration, StorageApi, Token, Network } = require('arweave-storage-sdk');
 
 const config = new Configuration({
-	appName: '<Name of your App>'
+	appName: '<Name of your App>',
 	privateKey: '<ENV to private key or use_web_wallet>',
 	network: Network.BASE_MAINNET,
 	token: Token.USDC
-})
+});
 
 const storageClient = new StorageApi(config);
-await storageApiInstance.ready
-
+await storageClient.ready;
 ```
 
 ### Authentication
@@ -73,8 +72,8 @@ await storageApiInstance.ready
 Once you have the storage client initialized and before you go ahead to upload any files, its really important to create a secured session by authenticating yourself. This allows you to track or query your uploads, receipts. It is easy and can be done in one line.
 
 ```javascript
-  //Login
-  await storageApiInstance.api.login()
+//Login
+await storageClient.api.login();
 ```
 
 And that's it. You’re ready to make authenticated requests with the service.
@@ -93,21 +92,23 @@ export interface GetEstimatesResponse {
   }
   payAddress: string
 }
-const size = file.size // 200000 bytes
-const estimates = await storageClient.getEstimates(size) // size of type number
+const size = file.size; // 200000 bytes
+const estimates = await storageClient.getEstimates(size); // size of type number
 
-console.log(estimates)
+console.log(estimates);
+/*
 { 
   "data": { 
-"size": 200000, 
-"usd": 0.008599242237052303, 
-"usdc": { 
-"amount": "0.0086", 
-"amountInSubUnits": "8600" 
-}, 
-"payAddress": "<USDC ADDRESS OF THE SERVICE>" 
+    "size": 200000, 
+    "usd": 0.008599242237052303, 
+    "usdc": { 
+      "amount": "0.0086", 
+      "amountInSubUnits": "8600" 
+    }, 
+    "payAddress": "<USDC ADDRESS OF THE SERVICE>" 
   } 
 }
+*/
 ```
 
 ### Quick file upload
@@ -117,16 +118,15 @@ Upload a file (or buffer) quickly using the quickUpload method.
 The `quickUpload` method simplifies the process of uploading a file to Arweave. It automatically handles the creation of the transaction, including setting metadata such as content type, visibility, and tags. The receipt returned includes the unique ID, to query and confirm the file upload.
 
 ```javascript
-
-const file = <web File object, file path, buffer or stream>const receipt = await storageClient.quickUpload(file, {
+const file = /* <web File object, file path, buffer or stream> */;
+const receipt = await storageClient.quickUpload(file, {
 	name: file.name || "test.txt",
 	dataContentType: 'text/plain', // content type of the file
-	visibility: '<public|private>',
-	tags: [{name: "Collection-Type", value: "ART"}],	size: file.size // size in bytes of type number
+	tags: [{name: "Collection-Type", value: "ART"}],
+	size: file.size // size in bytes of type number
 });
 
 console.log('File has been uploaded. receipt:', receipt.id);
-
 ```
 
 ### 
@@ -138,14 +138,12 @@ Create a new drive to manage your files on Arweave.
 Drives act as containers for your files and folders. The additional parameters such as visibility and tags help you categorize and control access to your content. This context is useful if you’re new to managing storage on decentralized platforms.
 
 ```javascript
-
-const drive = await storageClient.drive.create('My Drive', { 
-visibility: 'public',
-tags: [{name: "Collection-Type", value: "ART"}] 
+const drive = await storageClient.api.drive?.create('My Drive', { 
+	visibility: 'public',
+	tags: [{name: "Collection-Type", value: "ART"}] 
 });
 
-console.log('Drive created with ID:', drive.id);
-
+console.log('Drive created with ID:', drive?.id);
 ```
 
 ### 
@@ -157,16 +155,14 @@ Organize your files by creating folders within a drive.
 Folders help you structure your files within a drive. In this example, you can see how to specify the parent drive and (optionally) a parent folder to build a hierarchical file system. 
 
 ```javascript
-
-const folder = await storageClient.folder.create('My Folder', {
-driveId: '<driveId>',
-parentFolderId: '<parentFolderId>',
-visibility: 'public',
-tags: [{name: "Collection-Type", value: "ART"}]
+const folder = await storageClient.api.folder?.create('My Folder', {
+	driveId: '<driveId>',
+	parentFolderId: '<parentFolderId>',
+	visibility: 'public',
+	tags: [{name: "Collection-Type", value: "ART"}]
 });
 
-console.log('Folder created with ID:', folder.id);
-
+console.log('Folder created with ID:', folder?.id);
 ```
 
 ### Creating a File
@@ -176,10 +172,9 @@ Store a file on Arweave by creating a file transaction.
 This snippet creates a file by converting a string into a buffer and then sending it as a transaction to Arweave. The parameters include metadata like file name, size, and content type.
 
 ```javascript
-
 const fileData = Buffer.from('Hello, Arweave!');
 
-const file = await storageClient.file.create({
+const file = await storageClient.api.file?.create({
 	name: 'My File',
 	size: fileData.length,
 	dataContentType: 'text/plain',
@@ -190,8 +185,7 @@ const file = await storageClient.file.create({
 	tags: [{name: "Collection-Type", value: "ART"}]
 });
 
-console.log('File uploaded; transaction ID:', file.txId);
-
+console.log('File uploaded; transaction ID:', file?.dataTxId);
 ```
 
 **Note**: The `visibility` field can be set to `public` or `private`.
@@ -213,15 +207,14 @@ Arweave Storage SDK’s WalletService is designed to help you interact with your
 Initialize the **Arweave Storage SDK** object with various configuration options.  The `appName` is recommended as it helps in organizing and searching your transactions on Arweave. The `privateKey` can either be your account’s key or a flag to use a browser wallet. Other parameters like `network`, `token`, and `gateway` let you tailor the SDK to your specific environment.
 
 ```javascript
-
 const { Configuration, Network, Token} = require('arweave-storage-sdk');
 
 const config = new Configuration({
-	appName: 'My cool project'
+	appName: 'My cool project',
 	privateKey: process.env.PRIVATE_KEY,
 	network: Network.BASE_MAINNET,
 	token: Token.USDC
-})
+});
 ```
 
 | Option | Optional | Description |


### PR DESCRIPTION
`QuickUploadOptions` doesn't seem to support a `visibility` parameter (at least in the published package version `1.4.1`).  Is this a bug?  The code sample for it had a visibility field.